### PR TITLE
Adding class attribute

### DIFF
--- a/app/javascript/controllers/favorite_toggle_controller.ts
+++ b/app/javascript/controllers/favorite_toggle_controller.ts
@@ -1,6 +1,9 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class FavoriteToggleController extends Controller {
+  static classes = ["hidden"]
+  hiddenClass: string
+
   static targets = ["elementToHide", "elementWithText"]
   elementToHideTarget: HTMLElement
   elementWithTextTarget: HTMLElement
@@ -22,7 +25,7 @@ export default class FavoriteToggleController extends Controller {
   }
 
   updateHiddenClass(): void {
-    this.elementToHideTarget.classList.toggle("hidden", !this.visibleValue)
+    this.elementToHideTarget.classList.toggle(this.hiddenClass, !this.visibleValue)
   }
 
   newText(): string {

--- a/app/views/favorites/_list.html.erb
+++ b/app/views/favorites/_list.html.erb
@@ -2,7 +2,9 @@
   <section class="my-4" data-controller="favorite-toggle" data-favorite-toggle-visible-value="true">
     <div class="text-3xl font-bold">Favorite Concerts</div>
     <button class="<%= SimpleForm.button_class %> py-1 text-xl font-semibold" 
-            data-action="click->favorite-toggle#toggle" data-favorite-toggle-target="elementWithText">
+            data-action="click->favorite-toggle#toggle" 
+            data-favorite-toggle-target="elementWithText"
+            data-favorite-toggle-hidden-class="hidden">
       Hide
     </button>
     <div data-favorite-toggle-target="elementToHide">


### PR DESCRIPTION
This add the data-<controller-name>-<css-name>-class

Pros
- the controller is decoupled from CSS class name
- the CSS class name is now in the view
- Rails can control the CSS value